### PR TITLE
fix: undefined keyword argument `proxies` error | httpx error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,95 @@
+# Byte-compiled / optimized / compiled Python files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Virtual environment directories
+env/
+venv/
+ENV/
+.venv/
+analyst-copilot/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+*.wheel
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints
+
+# Pytest cache
+.pytest_cache/
+
+# Django stuff
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff
+instance/
+.webassets-cache
+
+# Scrapy stuff
+.scrapy/
+
+# Sphinx documentation
+docs/_build/
+
+# pyenv
+.python-version
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Coverage reports
+htmlcov/
+.coverage
+*.cover
+*.py,cover
+
+# Test artifacts
+.tox/
+.nox/
+*.test_report.json
+
+# Editor/IDE configurations
+.vscode/
+.idea/
+*.swp
+*~
+*.sublime-workspace
+*.sublime-project
+
+# macOS files
+.DS_Store
+
+# Windows files
+Thumbs.db
+desktop.ini
+
+# Anaconda environment files
+*.conda
+*.ipynb
+
+# Local overrides
+.env
+.env.*
+*.local
+
+# Temporary files
+*.tmp
+*.temp
+*.bak
+
+work_dir/
+.chainlit/
+.files/

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,7 @@ kaleido==0.2.1
 #UI
 chainlit==1.1.402
 nest-asyncio==1.6.0
+
+# error fix: newer version of httpx is incompatible with notebook and openai packages
+# read more at: https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332
+httpx==0.27.2

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -40,3 +40,7 @@ kaleido==0.2.1
 #UI
 chainlit==1.1.402
 nest-asyncio==1.6.0
+
+# error fix: newer version of httpx is incompatible with notebook and openai packages
+# read more at: https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332
+httpx==0.27.2


### PR DESCRIPTION
Was getting the following error while running the app:

```
2024-12-28 21:11:25 ai_teacher_container       | 2024-12-28 15:41:25 - Loaded .env file
2024-12-28 21:11:27 ai_teacher_container       | 2024-12-28 15:41:27 - Your app is available at http://localhost:8080
2024-12-28 21:12:25 ai_teacher_container       | 2024-12-28 15:42:25 - Translated markdown file for en-US not found. Defaulting to chainlit.md.
2024-12-28 21:12:33 ai_teacher_container       | 2024-12-28 15:42:33 - Client._init_() got an unexpected keyword argument 'proxies'
2024-12-28 21:12:33 ai_teacher_container       | Traceback (most recent call last):
2024-12-28 21:12:33 ai_teacher_container       |   File "/usr/local/lib/python3.12/site-packages/chainlit/utils.py", line 44, in wrapper
2024-12-28 21:12:33 ai_teacher_container       |     return await user_function(**params_values)
2024-12-28 21:12:33 ai_teacher_container       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-12-28 21:12:33 ai_teacher_container       |   File "/usr/local/lib/python3.12/site-packages/chainlit/step.py", line 112, in async_wrapper
2024-12-28 21:12:33 ai_teacher_container       |     result = await func(*args, **kwargs)
2024-12-28 21:12:33 ai_teacher_container       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-12-28 21:12:33 ai_teacher_container       |   File "/app/assistant.py", line 496, in start_message
2024-12-28 21:12:33 ai_teacher_container       |     model = OpenaiChatModel(model_name="gpt-4o",temperature=0)
2024-12-28 21:12:33 ai_teacher_container       |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-12-28 21:12:33 ai_teacher_container       |   File "/app/core/models.py", line 25, in _init_
2024-12-28 21:12:33 ai_teacher_container       |     self.client = OpenAI(api_key=self.api_key)
2024-12-28 21:12:33 ai_teacher_container       |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-12-28 21:12:33 ai_teacher_container       |   File "/usr/local/lib/python3.12/site-packages/openai/client.py", line 123, in __init_
2024-12-28 21:12:33 ai_teacher_container       |     super()._init_(
2024-12-28 21:12:33 ai_teacher_container       |   File "/usr/local/lib/python3.12/site-packages/openai/base_client.py", line 843, in __init_
2024-12-28 21:12:33 ai_teacher_container       |     self._client = http_client or SyncHttpxClientWrapper(
2024-12-28 21:12:33 ai_teacher_container       |                                   ^^^^^^^^^^^^^^^^^^^^^^^
2024-12-28 21:12:33 ai_teacher_container       |   File "/usr/local/lib/python3.12/site-packages/openai/base_client.py", line 741, in __init_
2024-12-28 21:12:33 ai_teacher_container       |     super()._init_(**kwargs)
2024-12-28 21:12:33 ai_teacher_container       | TypeError: Client._init_() got an unexpected keyword argument 'proxies'
```

The solution was to degrade the `httpx` package to version `0.27.2`
The error will persist in both the services, that is `jupyternotebook` and the `ai_teacher` because both internally uses the `httpx` package. 

Can read more about the issue [here](https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332)